### PR TITLE
Home assistant auto discovery

### DIFF
--- a/bin/elro
+++ b/bin/elro
@@ -8,9 +8,9 @@ from elro.hub import Hub
 from elro.mqtt import MQTTPublisher
 
 
-async def main(hostname, hub_id, mqtt_broker, base_topic):
+async def main(hostname, hub_id, mqtt_broker, ha_autodiscover, base_topic):
     hub = Hub(hostname, 1025, hub_id)
-    mqtt_publisher = MQTTPublisher(mqtt_broker, base_topic)
+    mqtt_publisher = MQTTPublisher(mqtt_broker, ha_autodiscover, base_topic)
     async with trio.open_nursery() as nursery:
         nursery.start_soon(mqtt_publisher.handle_hub_events, hub, name="hub_events")
         nursery.start_soon(hub.sender_task, name="hub_sender")
@@ -18,16 +18,21 @@ async def main(hostname, hub_id, mqtt_broker, base_topic):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(
+        format='[%(asctime)s] %(levelname)-8s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        level=logging.INFO
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--hostname", help="The hostname or ip of the K1 connector.")
     parser.add_argument("-i", "--id", help="The ID of the K1 connector (format is ST_xxxxxxxxxxxx).")
     parser.add_argument("-m", "--mqtt-broker", help="The IP of the MQTT broker.")
     parser.add_argument("-b", "--base-topic", help="The base topic of the MQTT topic.", default=None)
+    parser.add_argument("-a", "--ha-autodiscover", help="Send the devices automatically to Home Assistant.", action='store_true')
 
     args = parser.parse_args()
 
-    trio.run(main, args.hostname, args.id, args.mqtt_broker, args.base_topic)
+    trio.run(main, args.hostname, args.id, args.mqtt_broker, args.ha_autodiscover, args.base_topic)
 
 
 

--- a/elro/device.py
+++ b/elro/device.py
@@ -85,6 +85,7 @@ class Device(ABC):
         """
         Triggers the self.alarm event.
         """
+        self.device_state = 'Alarm'
         self.alarm.set()
         self.alarm = trio.Event()
 

--- a/elro/device.py
+++ b/elro/device.py
@@ -89,7 +89,7 @@ class Device(ABC):
         self.alarm.set()
         self.alarm = trio.Event()
 
-    def update(self, data):
+    def update(self, data, state="Unknown"):
         """
         Updates this device with the data received from the actual device
         :param data: The data dict received from the actual device
@@ -100,7 +100,7 @@ class Device(ABC):
         batt = int(data["data"]["device_status"][2:4], 16)
         self.battery_level = batt
 
-        self.device_state = "Unknown"
+        self.device_state = state
         self.update_specifics(data)
         self._send_update_event()
 
@@ -125,6 +125,7 @@ class Device(ABC):
         :return: A str containing json.
         """
         return json.dumps({"name": self.name,
+                           "device_name": self.name,
                            "id": self.id,
                            "type": self.device_type,
                            "state": self.device_state,

--- a/elro/hub.py
+++ b/elro/hub.py
@@ -145,7 +145,7 @@ class Hub:
         Handles all commands from the K1
         :param data: The data with the commands
         """
-        logging.debug(f"Handle command: {data}")
+        logging.info(f"Handle command: {data}")
         if data["data"]["cmdId"] == Command.DEVICE_STATUS_UPDATE.value:
             logging.debug(f"Processing cmdId: {data['data']['cmdId']}")
             if data["data"]["device_name"] == "STATUES":

--- a/elro/hub.py
+++ b/elro/hub.py
@@ -130,7 +130,7 @@ class Hub:
         :param data: The data to create the device from
         :return: The device object
         """
-        logging.info("Create device.")
+        logging.info(f"Create device with data: {data}")
         dev = create_device_from_data(data)
         d_id = data["data"]["device_ID"]
         if self.unregistered_names.get(d_id):
@@ -145,8 +145,9 @@ class Hub:
         Handles all commands from the K1
         :param data: The data with the commands
         """
-        logging.info(f"Handle command: {data}")
+        logging.debug(f"Handle command: {data}")
         if data["data"]["cmdId"] == Command.DEVICE_STATUS_UPDATE.value:
+            logging.debug(f"Processing cmdId: {data['data']['cmdId']}")
             if data["data"]["device_name"] == "STATUES":
                 return
 
@@ -162,15 +163,18 @@ class Hub:
             dev.update(data)
 
         elif data["data"]["cmdId"] == Command.DEVICE_ALARM_TRIGGER.value:
+            logging.debug(f"Processing cmdId: {data['data']['cmdId']}")
             d_id = int(data["data"]["answer_content"][6:10], 16)
             try:
                 dev = self.devices[d_id]
             except KeyError:
-                dev = await self.create_device(data)
+                #dev = await self.create_device(data)
+                return #device cannot be created from Command.DEVICE_ALARM_TRIGGER
             dev.send_alarm_event()
             logging.debug("ALARM!! Device_id " + str(d_id) + "(" + dev.name + ")")
 
         elif data["data"]["cmdId"] == Command.DEVICE_NAME_REPLY.value:
+            logging.debug(f"Processing cmdId: {data['data']['cmdId']}")
             answer = data["data"]["answer_content"]
             if answer == "NAME_OVER":
                 return

--- a/elro/mqtt.py
+++ b/elro/mqtt.py
@@ -39,21 +39,7 @@ class MQTTPublisher:
         The topic name for a given device
         :param device: The device to get the topic name for
         """
-        last_hierarchy = self.device_name(device)
-
-        return f"{self.base_topic}/elro/{last_hierarchy}"
-
-    def device_name(self, device):
-        """
-        The device name for a given device
-        :param device: The device to get the device name for
-        """
-        if device.name == "":
-            device_name = device.id
-        else:
-            device_name = device.name
-
-        return device_name
+        return f"{self.base_topic}/elro/{device.id}"
 
     async def device_alarm_task(self, device):
         """
@@ -71,7 +57,7 @@ class MQTTPublisher:
         await device.alarm.wait()
         async with open_mqttclient(uri=self.broker_host) as client:
             logging.info(f"Publish alarm on '{self.topic_name(device)}':\n"
-                         f"alarm")
+                         f"{device.json.encode('utf-8')}")
             await client.publish(f'{self.topic_name(device)}',
                                  device.json.encode('utf-8'),
                                  QOS_1)
@@ -113,12 +99,12 @@ class MQTTPublisher:
         #https://www.home-assistant.io/docs/mqtt/discovery/
         #https://www.home-assistant.io/integrations/sensor.mqtt/
         async with open_mqttclient(uri=self.broker_host) as client:
-            logging.info(f"Publish discovery on 'homeassistant/sensor/elro_k1/{self.device_name(device)}/config'")
+            logging.info(f"Publish discovery on 'homeassistant/sensor/elro_k1/{device.id}/config'")
             await client.publish(
-                f"homeassistant/sensor/elro_k1/{self.device_name(device)}/config",
+                f"homeassistant/sensor/elro_k1/{device.id}/config",
                 json.dumps(
                 {
-                    "name": f"{self.device_name(device)}",
+                    "name": f"elro_k1_{device.id}",
                     "state_topic": f"{self.topic_name(device)}",
                     "value_template": "{{ value_json.state }}",
                     "json_attributes_topic": f"{self.topic_name(device)}",

--- a/elro/mqtt.py
+++ b/elro/mqtt.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 import trio
 from distmqtt.client import open_mqttclient
@@ -14,10 +15,11 @@ class MQTTPublisher:
     """
     @accepts(broker_host=Pattern(f"({ip_address}|{hostname})"),
              base_topic=Pattern("^[/_\\-a-zA-Z0-9]*$"))
-    def __init__(self, broker_host, base_topic=None):
+    def __init__(self, broker_host, ha_autodiscover, base_topic=None):
         """
         Constructor
         :param broker_host: The MQTT broker host or ip
+        :param ha_autodiscover: If true, new devices will be automatically discovered by Home Assistant
         :param base_topic: The base topic to publish under, i.e., the publisher publishes messages under
                            <base topic>/elro/<device name or id>
         """
@@ -30,17 +32,28 @@ class MQTTPublisher:
         else:
             self.base_topic = base_topic
 
+        self.ha_autodiscover = ha_autodiscover
+
     def topic_name(self, device):
         """
         The topic name for a given device
         :param device: The device to get the topic name for
         """
-        if device.name == "":
-            last_hierarchy = device.id
-        else:
-            last_hierarchy = device.name
+        last_hierarchy = self.device_name(device)
 
         return f"{self.base_topic}/elro/{last_hierarchy}"
+
+    def device_name(self, device):
+        """
+        The device name for a given device
+        :param device: The device to get the device name for
+        """
+        if device.name == "":
+            device_name = device.id
+        else:
+            device_name = device.name
+
+        return device_name
 
     async def device_alarm_task(self, device):
         """
@@ -57,10 +70,10 @@ class MQTTPublisher:
         """
         await device.alarm.wait()
         async with open_mqttclient(uri=self.broker_host) as client:
-            logging.info(f"Publish on '{self.topic_name(device)}':\n"
+            logging.info(f"Publish alarm on '{self.topic_name(device)}':\n"
                          f"alarm")
             await client.publish(f'{self.topic_name(device)}',
-                                 b'alarm',
+                                 device.json.encode('utf-8'),
                                  QOS_1)
 
     async def device_update_task(self, device):
@@ -78,11 +91,41 @@ class MQTTPublisher:
         """
         await device.updated.wait()
         async with open_mqttclient(uri=self.broker_host) as client:
-            logging.info(f"Publish on '{self.topic_name(device)}':\n"
+            logging.info(f"Publish update on '{self.topic_name(device)}':\n"
                          f"{device.json.encode('utf-8')}")
             await client.publish(f'{self.topic_name(device)}',
                                  device.json.encode('utf-8'),
                                  QOS_1)
+
+    async def device_discovery_task(self, device):
+        """
+        The main handler for Home Assistant discovery
+        :param device: The device to handle discover event for.
+        """
+        if self.ha_autodiscover == True and device.device_type != "DEL":
+            await self.handle_device_discovery(device)
+
+    async def handle_device_discovery(self, device):
+        """
+        Add new devices automatically in Home Assistant
+        :param device: The device that will be added to Home Assistant
+        """
+        #https://www.home-assistant.io/docs/mqtt/discovery/
+        #https://www.home-assistant.io/integrations/sensor.mqtt/
+        async with open_mqttclient(uri=self.broker_host) as client:
+            logging.info(f"Publish discovery on 'homeassistant/sensor/elro_k1/{self.device_name(device)}/config'")
+            await client.publish(
+                f"homeassistant/sensor/elro_k1/{self.device_name(device)}/config",
+                json.dumps(
+                {
+                    "name": f"{self.device_name(device)}",
+                    "state_topic": f"{self.topic_name(device)}",
+                    "value_template": "{{ value_json.state }}",
+                    "json_attributes_topic": f"{self.topic_name(device)}",
+                    "unique_id": f"elro_k1_device_{device.id}"
+                }).encode('utf8'),
+                QOS_1
+            )
 
     async def handle_hub_events(self, hub):
         """
@@ -94,3 +137,4 @@ class MQTTPublisher:
                 logging.info(f"New device registered: {hub.devices[device_id]}")
                 nursery.start_soon(self.device_update_task, hub.devices[device_id])
                 nursery.start_soon(self.device_alarm_task, hub.devices[device_id])
+                nursery.start_soon(self.device_discovery_task, hub.devices[device_id])

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -7,7 +7,7 @@ from elro.device import AlarmSensor, DeviceType
 
 @pytest.fixture
 def client():
-    client = elro.mqtt.MQTTPublisher("test", "/test")
+    client = elro.mqtt.MQTTPublisher("test", True, "/test")
     return client
 
 
@@ -26,7 +26,9 @@ async def test_handle_device_alarm_sends_alarm_message(client, mock_device):
         await client.handle_device_alarm(mock_device)
     mock_device.alarm.wait.assert_called_once()
     publisher = mock_open_client.return_value.__aenter__.return_value.publish
-    publisher.assert_called_with('/test/elro/yoda', b'alarm', 1)
+    publisher.assert_called_with('/test/elro/42',
+                                 b'{"name": "yoda", "device_name": "yoda", "id": "42", "type": "0101", "state": "Alarm", "battery": 100}',
+                                 1)
 
 
 async def test_handle_device_update_sends_update_message(client, mock_device):
@@ -35,6 +37,15 @@ async def test_handle_device_update_sends_update_message(client, mock_device):
         await client.handle_device_update(mock_device)
     mock_device.updated.wait.assert_called_once()
     publisher = mock_open_client.return_value.__aenter__.return_value.publish
-    publisher.assert_called_with('/test/elro/yoda',
-                                 b'{"name": "yoda", "id": "42", "type": "0101", "state": "", "battery": -1}',
+    publisher.assert_called_with('/test/elro/42',
+                                 b'{"name": "yoda", "device_name": "yoda", "id": "42", "type": "0101", "state": "", "battery": -1}',
+                                 1)
+
+async def test_handle_device_update_sends_update_message(client, mock_device):
+    with asynctest.mock.patch("elro.mqtt.open_mqttclient") as mock_open_client:
+        mock_open_client.return_value.__aenter__.return_value.publish = CoroutineMock()
+        await client.handle_device_discovery(mock_device)
+    publisher = mock_open_client.return_value.__aenter__.return_value.publish
+    publisher.assert_called_with('homeassistant/sensor/elro_k1/42',
+                                 b'{"name": "elro_k1_42", "state_topic": "test/elro/42", "value_template": "{{ value_json.state }}", "json_attributes_topic": "test/elro/42", "unique_id": "elro_k1_device_42"}',
                                  1)


### PR DESCRIPTION
This PR adds the ability for ELRO Connects to add the ELRO devices automatically to Home Assistant. Users can decide if they want this by only providing -a on the commandline. This makes it easy to use this tool with HA. I am also planning to create a HA addon to run ELRO Connects, it makes this tool more user friendly IMO.

To better support Home Assistant, the property State is now used to show the Alarm state instead of only using "alarm" as MQTT payload. Home Assistant is unable to know the state if the payload differs.

I hope the implementation has been done correctly.

#14 is also solved within hub.py line 17. To find the issue, I added some debug logging. To have better insights in what is happening when, the logging now shows timestamps.