### PR TITLE
Fixed setting device state

### DIFF
--- a/elro/mqtt.py
+++ b/elro/mqtt.py
@@ -156,9 +156,9 @@ class MQTTPublisher:
                             if "name" in mqtt_message_json and device_index != 0:
                                 await hub.set_device_name(device_index, mqtt_message_json["name"])
                             elif "state" in mqtt_message_json:
-                                if mqtt_message_json["test alarm"].lower() == 'test alarm':
+                                if mqtt_message_json["state"].lower() == 'test alarm':
                                     await hub.set_device_state(device_index, '17')
-                                elif mqtt_message_json["test alarm"].lower() == 'silence' and device_index == 0:
+                                elif mqtt_message_json["state"].lower() == 'silence' and device_index == 0:
                                     await hub.set_device_state(device_index, '00')
                                 else:
                                     logging.warning(f"Unable to set state with incorrect message '{mqtt_message}' and/or topic '{msg.topic}'")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = elro_connects
 author = Bas van den Berg, Johannes Kulick
-version = 0.3.2
+version = 0.3.3
 description = Connects to an Elro Connects K1 Connector and provides MQTT channels from the devices status
 long_description = file: README.md, LICENSE
 license = MIT License


### PR DESCRIPTION
Setting device state was expecting the `state` key but was actually looking for the value in the `test alarm` key.