### PR TITLE
fix for issue 27

### DIFF
--- a/elro/mqtt.py
+++ b/elro/mqtt.py
@@ -110,7 +110,8 @@ class MQTTPublisher:
                     "json_attributes_topic": f"{self.topic_name(device)}",
                     "unique_id": f"elro_k1_device_{device.id}"
                 }).encode('utf8'),
-                QOS_1
+                QOS_1,
+                retain=True
             )
 
     async def device_message_task(self, hub):


### PR DESCRIPTION
fixes [issue #27](https://github.com/dib0/elro_connects/issues/26). The auto configuraiton messages shouldget the retain flag as described [here](https://www.home-assistant.io/docs/mqtt/discovery/#motion-detection-binary-sensor).

> Retain: The -r switch is added to retain the configuration topic in the broker. Without this, the sensor will not be available after Home Assistant restarts.