### PR TITLE
More device types and added explicit unsupported type

### DIFF
--- a/elro/device.py
+++ b/elro/device.py
@@ -67,9 +67,8 @@ class Device(ABC):
         self._battery_level = -1
         self._signal_strength = -1
         self._device_state = ""
-        self.device_type = DeviceType(device_type_id)
         self.device_type_id = device_type_id
-        self.device_type_name = self.device_type.name
+        self.device_type = DeviceType(self.device_type_id)
         self.updated = trio.Event()
         self.alarm = trio.Event()
 
@@ -146,6 +145,7 @@ class Device(ABC):
         :param data: The data dict received from the actual device
         """
         self.device_type_id = data["data"]["device_name"]
+        self.device_type = DeviceType(self.device_type_id)
 
         # set signal status
         sig = int(data["data"]["device_status"][0:2], 16)
@@ -184,7 +184,7 @@ class Device(ABC):
                            "device_name": self.name,
                            "id": self.id,
                            "type": self.device_type_id,
-                           "type_name": self.device_type_name,
+                           "type_name": self.device_type.name,
                            "state": self.device_state,
                            "battery": self.battery_level,
                            "signal": self.signal_strength})

--- a/elro/device.py
+++ b/elro/device.py
@@ -11,10 +11,29 @@ class DeviceType(Enum):
     The DeviceType defines which kind of Elro device this is
     """
     CO_ALARM = "0000","1000","2000","0008","1008","2008","000E","100E","200E"
+    GAS_ALARM = "0002","1002","2002","1006","000A","100A","200A"
+    SMOKE_ALARM = "0001","1001","2001","0009","1009","2009"
     WATER_ALARM = "0004","1004","2004","000C","100C","200C","0012","1012","2012"
     HEAT_ALARM = "0003","1003","2003","000B","100B","200B","0011","1011","2011"
     FIRE_ALARM = "0005","1109","2109","000D","100D","200D","0013","1013","2013"
-    DOOR_WINDOW_SENSOR = "0101","1101","2101"
+
+    GUARD = "0210","1210","2210" # access control
+    TEMPERATURE_SENSOR = "0102","1102","2102" # TH_CHECK
+    DOOR_WINDOW_SENSOR = "0101","1101","2101"   # DOOR_CHECK
+
+    LOCK = "1213"
+    MODE_BUTTON = "0305"
+    BUTTON = "0301","1301","2301"
+    LAMP = "020A","120A","220A"
+    SOCKET = "0200","1200","2200"
+    TWO_SOCKET = "0201","1201","2201"
+    VALVE = "0208","1208","2208"
+    CURTAIN = "0209","1209","2209"
+    TEMP_CONTROL = "0215","1215","2215"
+    DIMMING_MODULE = "0214","1214","2214"
+
+    SOS_KEY = "0300","1300","2300"
+    PIR_CHECK = "0100","1100","2100"
 
     def __new__(cls, *values):
         obj = object.__new__(cls)
@@ -37,7 +56,7 @@ class Device(ABC):
     """
     A Device is an Elro device that is connected to the system
     """
-    def __init__(self, device_id, device_type):
+    def __init__(self, device_id, device_type_id):
         """
         Constructor
         :param device_id: The device ID
@@ -48,8 +67,9 @@ class Device(ABC):
         self._battery_level = -1
         self._signal_strength = -1
         self._device_state = ""
-        self.device_type = device_type
-        self.device_type_name = DeviceType(device_type).name
+        self.device_type = DeviceType(device_type_id)
+        self.device_type_id = device_type_id
+        self.device_type_name = self.device_type.name
         self.updated = trio.Event()
         self.alarm = trio.Event()
 
@@ -125,7 +145,7 @@ class Device(ABC):
         Updates this device with the data received from the actual device
         :param data: The data dict received from the actual device
         """
-        self.device_type = data["data"]["device_name"]
+        self.device_type_id = data["data"]["device_name"]
 
         # set signal status
         sig = int(data["data"]["device_status"][0:2], 16)
@@ -149,7 +169,7 @@ class Device(ABC):
         pass
 
     def __str__(self):
-        return f"<{self.device_type}: {self.name} (id: {self.id})>"
+        return f"<{self.device_type_id}: {self.name} (id: {self.id})>"
 
     def __repr__(self):
         return str(self)
@@ -163,7 +183,7 @@ class Device(ABC):
         return json.dumps({"name": self.name,
                            "device_name": self.name,
                            "id": self.id,
-                           "type": self.device_type,
+                           "type": self.device_type_id,
                            "type_name": self.device_type_name,
                            "state": self.device_state,
                            "battery": self.battery_level,
@@ -174,12 +194,13 @@ class WindowSensor(Device):
     """
     A sensor that can detect open/close state of a window.
     """
-    def __init__(self, device_id):
+    def __init__(self, device_id, device_type_id):
         """
         Constructor
         :param device_id: The device ID
+        :param device_type_id: The device type id
         """
-        super().__init__(device_id, "0101")
+        super().__init__(device_id, device_type_id)
 
     def update_specifics(self, data):
         """
@@ -187,13 +208,13 @@ class WindowSensor(Device):
         :param data: The data dict received from the actual device
         """
         if DeviceType(data["data"]["device_name"]) != DeviceType.DOOR_WINDOW_SENSOR:
-            AttributeError(f"Tried to update a window sensor to type "
-                           f"{DeviceType(data['data']['device_name'])}")
+            logging.error(f"Tried to update a window sensor to type '{DeviceType(data['data']['device_name'])}'")
 
-        if data["data"]["device_status"][4:-2] == "55":
+        state = data["data"]["device_status"][4:-2]
+        if state == "55":
             logging.debug("Door/window id " + str(self.id) + " open!")
             self.device_state = "Open"
-        elif data["data"]["device_status"][4:-2] == "AA":
+        elif state == "AA":
             logging.debug("Door/window id " + str(self.id) + " closed!")
             self.device_state = "Closed"
 
@@ -202,13 +223,13 @@ class AlarmSensor(Device):
     """
     A device that can ring an alarm (HeatAlarm, WaterAlarm, FireAlarm, COAlarm)
     """
-    def __init__(self, device_id, device_type):
+    def __init__(self, device_id, device_type_id):
         """
         Constructor
         :param device_id: The device ID
-        :param device_type: The device type
+        :param device_type_id: The device type id
         """
-        super().__init__(device_id, device_type)
+        super().__init__(device_id, device_type_id)
 
     def update_specifics(self, data):
         """
@@ -216,18 +237,17 @@ class AlarmSensor(Device):
         :param data: The data dict received from the actual device
         """
         state = data["data"]["device_status"][4:-2]
-        device_type = DeviceType(self.device_type)
         state_name = None
 
         #CO, WATER and HEAT_ALARM specific status
-        if device_type == DeviceType.CO_ALARM or device_type == DeviceType.WATER_ALARM or device_type == DeviceType.HEAT_ALARM:
+        if self.device_type == DeviceType.CO_ALARM or self.device_type == DeviceType.WATER_ALARM or self.device_type == DeviceType.HEAT_ALARM:
             if state == "11":
                 state_name = "Illegal demolition"
             elif state == "50":
                 state_name = "Normal"
 
         #FIRE_ALARM specific status
-        if device_type == DeviceType.FIRE_ALARM:
+        if self.device_type == DeviceType.FIRE_ALARM:
             if state == "12":
                 state_name = "Fault"
             elif state == "15":
@@ -256,6 +276,29 @@ class AlarmSensor(Device):
         self.device_state = state_name
         logging.debug(f"AlarmSensor with id '{self.id}' has got the device_state '{self.device_state}'")
 
+class Unsupported(Device):
+    """
+    Device used when no other match is available.
+    """
+    def __init__(self, device_id, device_type_id):
+        """
+        Constructor
+        :param device_id: The device ID
+        :param device_type_id: The device type id
+        """
+        logging.warning(f"Creating an unsupported device ({device_id}) type '{DeviceType(device_type_id)}'")
+        super().__init__(device_id, device_type_id)
+
+    def update_specifics(self, data):
+        """
+        :param data: The data dict received from the actual device
+        """
+        logging.warning(f"Updating an unsupported device type '{self.device_type}'")
+
+        state = data["data"]["device_status"][4:-2]
+        if state == "FF":
+            logging.debug("Unsupported device with id " + str(self.id) + " offline!")
+            self.device_state = "Offline"
 
 def create_device_from_data(data):
     """
@@ -263,10 +306,19 @@ def create_device_from_data(data):
     :param data: The data dict received from the actual device
     :return: A Device object
     """
-    if data["data"]["device_name"] == "DEL":
-        logging.warning(f"Got device_name 'DEL' for device_id '{(data['data']['device_ID'])}'")
+    
+    device_id = data["data"]["device_ID"]
+    device_type_id = data["data"]["device_name"]
+
+    if device_type_id == "DEL":
+        logging.warning(f"Got device_name 'DEL' for device_id '{(device_id)}'")
         return None
-    elif DeviceType(data["data"]["device_name"]) == DeviceType.DOOR_WINDOW_SENSOR:
-        return WindowSensor(data["data"]["device_ID"])
     else:
-        return AlarmSensor(data["data"]["device_ID"], data["data"]["device_name"])
+        devType = DeviceType(device_type_id)
+        match devType:
+            case DeviceType.DOOR_WINDOW_SENSOR:
+                return WindowSensor(device_id, device_type_id)
+            case DeviceType.CO_ALARM | DeviceType.GAS_ALARM | DeviceType.SMOKE_ALARM | DeviceType.WATER_ALARM | DeviceType.HEAT_ALARM | DeviceType.FIRE_ALARM:
+                return AlarmSensor(device_id, device_type_id)
+            case _:
+                return Unsupported(device_id, device_type_id)


### PR DESCRIPTION
Added all currently know device types and unsupported device for those not yet supported. This so that all device would at least show up and register without crashing things.

Also changed `device_type` to `device_type_id` and added the actual device type enum as `device_type`. 

Tests still need to be added but I first wanted some feedback.

This also lays some groundwork for https://github.com/dib0/elro_connects/issues/33.